### PR TITLE
Eye of Ayak fixes

### DIFF
--- a/src/main/java/com/tickcounter/ExtendedAnimation.java
+++ b/src/main/java/com/tickcounter/ExtendedAnimation.java
@@ -5,8 +5,7 @@ public class ExtendedAnimation
 	public int delta;
 	public int animation;
 	public int weapon;
-	public int lastTick = 0;
-	public boolean firstHit = true;
+	public int lastTick;
 
 	public ExtendedAnimation(int delta, int animation, int weapon, int currentTick)
 	{
@@ -14,5 +13,10 @@ public class ExtendedAnimation
 		this.animation = animation;
 		this.weapon = weapon;
 		this.lastTick = currentTick;
+	}
+
+	public int eligibleAt()
+	{
+		return lastTick + delta;
 	}
 }

--- a/src/main/java/com/tickcounter/ExtendedAnimation.java
+++ b/src/main/java/com/tickcounter/ExtendedAnimation.java
@@ -1,0 +1,14 @@
+package com.tickcounter;
+
+public class ExtendedAnimation
+{
+	public int delta;
+	public int weapon;
+	public int lastTick = 0;
+
+	ExtendedAnimation(int delta, int weapon)
+	{
+		this.delta = delta;
+		this.weapon = weapon;
+	}
+}

--- a/src/main/java/com/tickcounter/ExtendedAnimation.java
+++ b/src/main/java/com/tickcounter/ExtendedAnimation.java
@@ -3,12 +3,16 @@ package com.tickcounter;
 public class ExtendedAnimation
 {
 	public int delta;
+	public int animation;
 	public int weapon;
 	public int lastTick = 0;
+	public boolean firstHit = true;
 
-	ExtendedAnimation(int delta, int weapon)
+	public ExtendedAnimation(int delta, int animation, int weapon, int currentTick)
 	{
 		this.delta = delta;
+		this.animation = animation;
 		this.weapon = weapon;
+		this.lastTick = currentTick;
 	}
 }

--- a/src/main/java/com/tickcounter/TickCounterPlugin.java
+++ b/src/main/java/com/tickcounter/TickCounterPlugin.java
@@ -48,7 +48,7 @@ public class TickCounterPlugin extends Plugin
 
 	Map<String, Integer> activity = new HashMap<>();
 
-	private HashMap<Player, Boolean> blowpiping = new HashMap<>();
+	private HashMap<Player, ExtendedAnimation> extendedAnims = new HashMap<>();
 	boolean instanced = false;
 	boolean prevInstance = false;
 
@@ -90,7 +90,7 @@ public class TickCounterPlugin extends Plugin
 			case 10656: // blazing blowpipe
 				if (weapon == 12926 || weapon == 28688)
 				{
-					blowpiping.put(p, Boolean.FALSE);
+					extendedAnims.put(p, new ExtendedAnimation(2, weapon));
 				}
 				else
 				{
@@ -104,7 +104,13 @@ public class TickCounterPlugin extends Plugin
 			case 11057: // Eclipse atlatl
 			case 11060: // Eclipse atlatl spec
 			case 12397: // Eye of Ayak
-				delta = 3;
+				if (weapon == 31113) {
+					extendedAnims.put(p, new ExtendedAnimation(3, weapon));
+				}
+				else
+				{
+					delta = 3;
+				}
 				break;
 			case 426: // bow shoot
 				if (weapon == 11235 || weapon == 12765 || weapon == 12766 || weapon == 12767 || weapon == 12768 || weapon == 27853) // dark bow
@@ -279,7 +285,13 @@ public class TickCounterPlugin extends Plugin
 			case 10173: // Soulreaper axe spec
 			case 11222: // Osmumten's fang Special
 			case 12394: // Eye of Ayak Special
-				delta = 5;
+				if (weapon == 31113) {
+					extendedAnims.put(p, new ExtendedAnimation(5, weapon));
+				}
+				else
+				{
+					delta = 5;
+				}
 				break;
 			case 401:
 				if (weapon == 13576) // dwh bop
@@ -332,7 +344,7 @@ public class TickCounterPlugin extends Plugin
 				delta = 8;
 				break;
 			case -1:
-				blowpiping.remove(p);
+				extendedAnims.remove(p);
 				break;
 		}
 		if (delta > 0)
@@ -345,20 +357,21 @@ public class TickCounterPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick tick)
 	{
-		for (Map.Entry<Player, Boolean> entry : blowpiping.entrySet())
+		final int currentTick = client.getTickCount();
+
+		for (Map.Entry<Player, ExtendedAnimation> entry : extendedAnims.entrySet())
 		{
-			if (entry.getValue())
+			ExtendedAnimation extAnim = entry.getValue();
+			if (extAnim.lastTick == 0 || currentTick >= (extAnim.delta + extAnim.lastTick))
 			{
 				String name = entry.getKey().getName();
 				int activity = this.activity.getOrDefault(name, 0).intValue();
-				this.activity.put(name, activity + 2);
-				blowpiping.put(entry.getKey(), Boolean.FALSE);
-			}
-			else
-			{
-				blowpiping.put(entry.getKey(), Boolean.TRUE);
+				this.activity.put(name, activity + extAnim.delta);
+				extAnim.lastTick = currentTick;
+				extendedAnims.put(entry.getKey(), extAnim);
 			}
 		}
+
 		prevInstance = instanced;
 		instanced = client.isInInstancedRegion();
 		if (resetOnInstance && !prevInstance && instanced)
@@ -407,6 +420,6 @@ public class TickCounterPlugin extends Plugin
 	private void reset()
 	{
 		activity.clear();
-		blowpiping.clear();
+		extendedAnims.clear();
 	}
 }

--- a/src/main/java/com/tickcounter/TickCounterPlugin.java
+++ b/src/main/java/com/tickcounter/TickCounterPlugin.java
@@ -183,6 +183,7 @@ public class TickCounterPlugin extends Plugin
 			case 8289: // dhl slash
 			case 8290: // dhl crush
 			case 4503: // inquisitor's mace crush
+			case 12342: // earthbound tecpatl
 				delta = 4;
 				break;
 			case 1710: // zamorakian spear stab

--- a/src/main/java/com/tickcounter/TickCounterPlugin.java
+++ b/src/main/java/com/tickcounter/TickCounterPlugin.java
@@ -361,13 +361,22 @@ public class TickCounterPlugin extends Plugin
 		else if (extAnim != null) // new extended animation (blowpipe/ayak)
 		{
 			extendedAnims.put(p, extAnim);
-			logExtendedActivity(p, currentTick, extAnim); // track first hit activity immediately
 		}
 
 		// Extended animation reset (ie stop attacking or changed to non-tracking animation)
-		if (curExtAnim != null && delta != 0)
+		if (curExtAnim != null && (delta != 0 || extAnim != null))
 		{
-			extendedAnims.remove(p);
+			// track pending activity if eligible
+			if (currentTick >= curExtAnim.eligibleAt() || extAnim != null)
+			{
+				logExtendedActivity(p, currentTick, curExtAnim);
+			}
+
+			// remove if animation changed or reset
+			if (delta != 0)
+			{
+				extendedAnims.remove(p);
+			}
 		}
 	}
 
@@ -379,16 +388,9 @@ public class TickCounterPlugin extends Plugin
 		for (Map.Entry<Player, ExtendedAnimation> entry : extendedAnims.entrySet())
 		{
 			ExtendedAnimation extAnim = entry.getValue();
-			if (currentTick >= (extAnim.lastTick + extAnim.delta))
+			if (currentTick >= extAnim.eligibleAt())
 			{
-				if (!extAnim.firstHit) // first hit is already tracked immediately on animation change
-				{
-					logExtendedActivity(entry.getKey(), currentTick, extAnim);
-				}
-				else
-				{
-					extAnim.firstHit = false;
-				}
+				logExtendedActivity(entry.getKey(), currentTick, extAnim);
 			}
 		}
 


### PR DESCRIPTION
A couple of weeks ago, I added Eye of Ayak (#21). I was testing on men in Edgeville, and the tick counter works as expected (*not really*), but I later noticed that with continuous attacks (ie not 1-hitting the npc) your subsequent ticks are not counted. Sorry I didn't notice this during initial testing!

I have started testing on the new Gemstone crab, and I have done some investigating, and the `AnimationChanged` event is not fired multiple times for hits with the Ayak(???). 

**4 hits with Sang staff**

```
2025-08-23 10:38:24 BST [Client] DEBUG com.tickcounter.TickCounterPlugin - Animation: 11430, Weapon: 25731
2025-08-23 10:38:25 BST [Client] DEBUG com.tickcounter.TickCounterPlugin - Animation: -1, Weapon: 25731
2025-08-23 10:38:26 BST [Client] DEBUG com.tickcounter.TickCounterPlugin - Animation: 11430, Weapon: 25731
2025-08-23 10:38:27 BST [Client] DEBUG com.tickcounter.TickCounterPlugin - Animation: -1, Weapon: 25731
2025-08-23 10:38:29 BST [Client] DEBUG com.tickcounter.TickCounterPlugin - Animation: 11430, Weapon: 25731
2025-08-23 10:38:29 BST [Client] DEBUG com.tickcounter.TickCounterPlugin - Animation: -1, Weapon: 25731
2025-08-23 10:38:31 BST [Client] DEBUG com.tickcounter.TickCounterPlugin - Animation: 11430, Weapon: 25731
2025-08-23 10:38:32 BST [Client] DEBUG com.tickcounter.TickCounterPlugin - Animation: -1, Weapon: 25731
```

**4 hits with Ayak**

```
2025-08-23 10:39:28 BST [Client] DEBUG com.tickcounter.TickCounterPlugin - Animation: 12397, Weapon: 31113
2025-08-23 10:39:35 BST [Client] DEBUG com.tickcounter.TickCounterPlugin - Animation: -1, Weapon: 31113
```

The `12397` Ayak animation is fired when we start attacking, and the `-1` animation is fired when we stop. This looks to me to be the same as a blowpipe, so I have refactored how blowpipes are handled to support multiple weapons and deltas. Below are some videos before and start the patch. 

**Ayak broken**: https://streamable.com/x5j8aa
**Ayak fixed**: https://streamable.com/49ne3z

I've noticed sometimes that extra ticks gained after an Ayak special (see 2nd video), and this may be how the extended animations are handled within `onGameTick`. I'm going to do a bit more debugging tomorrow to see if I can fix this. If anyone else could take a look and test it would also be appreciated :heart: 

Again, apologies for not noticing this sooner!

Probably related: #22